### PR TITLE
Added set error flag to report intermediate cmd failure

### DIFF
--- a/finish/name/Dockerfile
+++ b/finish/name/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/finish/ping/Dockerfile
+++ b/finish/ping/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war

--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 ##############################################################################
 ##
@@ -6,29 +7,20 @@
 ##
 ##############################################################################
 
-printf "\nmvn -q package\n"
 mvn -q package
 
-printf "\nkubectl apply -f kubernetes.yaml\n"
 kubectl apply -f kubernetes.yaml
 
-printf "\nsleep 120\n"
 sleep 120
 
-printf "\nkubectl get pods\n"
 kubectl get pods
 
-printf "\nminikube ip\n"
 echo `minikube ip`
 
-printf "\nmvn verify -Ddockerfile.skip=true -Dcluster.ip=`minikube ip`\n"
 mvn verify -Ddockerfile.skip=true -Dcluster.ip=`minikube ip`
 
-printf "\nkubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep name | head -1)\n"
 kubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep name | head -1)
 
-printf "\nkubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep name | tail -1)\n"
 kubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep name | tail -1)
 
-printf "\nkubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep ping)\n"
 kubectl logs $(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep ping)

--- a/start/name/Dockerfile
+++ b/start/name/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/start/ping/Dockerfile
+++ b/start/ping/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war


### PR DESCRIPTION
- fixed the test script to fail at intermediate steps with the `set -e` bash script flag
  - reference info for the `set -euxo pipefail` flag : https://coderwall.com/p/fkfaqq/safer-bash-scripts-with-set-euxo-pipefail
- addressed issues reported in https://github.com/openliberty/guides-common/issues/223